### PR TITLE
feat: support interpolating hyphen to underscore

### DIFF
--- a/interpolator/interpolator.go
+++ b/interpolator/interpolator.go
@@ -111,8 +111,10 @@ func (i *Interpolator) Interpolate(k, v string) (string, bool) {
 func (i *Interpolator) checkAttributes(sk []string, v string, ngi int, ng string, rns map[string]map[string]string) string {
 	for rn, attrs := range rns {
 		att := strings.Join(sk[(len(sk)-(ngi)):len(sk)], "_")
-		if av, ok := attrs[att]; ok && strings.ToLower(av) == strings.ToLower(v) {
-			return fmt.Sprintf("${%s.%s.%s}", fmt.Sprintf("%s_%s", i.provider, ng), rn, att)
+		if av, ok := attrs[att]; ok {
+			if strings.Replace(strings.ToLower(av), "-", "_", -1) == strings.ToLower(v) || strings.ToLower(av) == strings.ToLower(v) {
+				return fmt.Sprintf("${%s.%s.%s}", fmt.Sprintf("%s_%s", i.provider, ng), rn, att)
+			}
 		}
 	}
 	// Then if no exact we try to find first one with the same value on the resource

--- a/interpolator/interpolator_test.go
+++ b/interpolator/interpolator_test.go
@@ -8,32 +8,47 @@ import (
 )
 
 func TestInterpolate(t *testing.T) {
-	i := interpolator.New("azurerm")
-	i.AddResourceAttributes("azurerm_virtual_machine.front", map[string]string{
-		"id":    "secretid",
-		"other": "ovalue",
+
+	t.Run("normal cases", func(t *testing.T) {
+		i := interpolator.New("azurerm")
+		i.AddResourceAttributes("azurerm_virtual_machine.front", map[string]string{
+			"id":    "secretid",
+			"other": "ovalue",
+		})
+		i.AddResourceAttributes("azurerm_virtual_something.front", map[string]string{
+			"id": "secretid",
+		})
+
+		s, ok := i.Interpolate("virtual_machine_id", "secretid")
+		assert.Equal(t, s, "${azurerm_virtual_machine.front.id}")
+		assert.True(t, ok)
+
+		s, ok = i.Interpolate("virtual_machine_potato", "ovalue")
+		assert.Equal(t, s, "${azurerm_virtual_machine.front.other}")
+		assert.True(t, ok)
+
+		s, ok = i.Interpolate("totally_random", "secretid")
+		assert.Equal(t, s, "${azurerm_virtual_something.front.id}")
+		assert.True(t, ok)
+
+		s, ok = i.Interpolate("virtual_id", "secretid")
+		assert.Equal(t, s, "${azurerm_virtual_machine.front.id}")
+		assert.True(t, ok)
+
+		s, ok = i.Interpolate("virtual_machine_potato", "none")
+		assert.Equal(t, s, "")
+		assert.False(t, ok)
+
 	})
-	i.AddResourceAttributes("azurerm_virtual_something.front", map[string]string{
-		"id": "secretid",
+
+	t.Run("resource id is uses hyphen, but but resource is underscore", func(t *testing.T) {
+		aws := interpolator.New("aws")
+		aws.AddResourceAttributes("aws_security_group.sg_test", map[string]string{
+			"id":          "sg-test",
+			"description": "security groups",
+		})
+		s, ok := aws.Interpolate("security_group_id", "sg_test")
+		assert.Equal(t, s, "${aws_security_group.sg_test.id}")
+		assert.True(t, ok)
 	})
-
-	s, ok := i.Interpolate("virtual_machine_id", "secretid")
-	assert.Equal(t, s, "${azurerm_virtual_machine.front.id}")
-	assert.True(t, ok)
-
-	s, ok = i.Interpolate("virtual_machine_potato", "ovalue")
-	assert.Equal(t, s, "${azurerm_virtual_machine.front.other}")
-	assert.True(t, ok)
-
-	s, ok = i.Interpolate("totally_random", "secretid")
-	assert.Equal(t, s, "${azurerm_virtual_something.front.id}")
-	assert.True(t, ok)
-
-	s, ok = i.Interpolate("virtual_id", "secretid")
-	assert.Equal(t, s, "${azurerm_virtual_machine.front.id}")
-	assert.True(t, ok)
-
-	s, ok = i.Interpolate("virtual_machine_potato", "none")
-	assert.Equal(t, s, "")
-	assert.False(t, ok)
 }


### PR DESCRIPTION
example: resource id sg-<unique> is interpolating to terraform resource id that is sg_<unique>